### PR TITLE
Renamed CO2FootprintObserver to CO2FootprintTextFileObserver

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -28,8 +28,8 @@ class CO2FootprintConfig {
 
     CO2FootprintConfig(Map map){
         def config = map ?: Collections.emptyMap()
-        file = config.file ?: CO2FootprintObserver.DEF_FILE_NAME
-        summaryFile = config.summaryFile ?: CO2FootprintObserver.DEF_SUMMARY_FILE_NAME
+        file = config.file ?: CO2FootprintTextFileObserver.DEF_FILE_NAME
+        summaryFile = config.summaryFile ?: CO2FootprintTextFileObserver.DEF_SUMMARY_FILE_NAME
     }
 
     String getFile() { file }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -23,7 +23,6 @@ import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.trace.TraceObserver
 import nextflow.trace.TraceObserverFactory
-import nextflow.trace.TraceFileObserver
 
 /**
  * Implements the validation observer factory
@@ -48,7 +47,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
         def co2eSummaryFile = (this.config.getSummaryFile() as Path).complete()
 
         final result = new ArrayList(2)
-        result.add( new CO2FootprintObserver(co2eFile, co2eSummaryFile) )
+        result.add( new CO2FootprintTextFileObserver(co2eFile, co2eSummaryFile) )
 
         return result
     }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintTextFileObserver.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintTextFileObserver.groovy
@@ -40,7 +40,7 @@ import nextflow.processor.TaskProcessor
 
 @Slf4j
 @CompileStatic
-class CO2FootprintObserver implements TraceObserver {
+class CO2FootprintTextFileObserver implements TraceObserver {
 
     // TODO which files should we generate here?
     public static final String DEF_FILE_NAME         = "co2footprint-${TraceHelper.launchTimestampFmt()}.txt"
@@ -83,7 +83,7 @@ class CO2FootprintObserver implements TraceObserver {
      *
      * @param co2eFile A path to the file where save the CO2 emission data
      */
-    CO2FootprintObserver( Path co2eFile, Path co2eSummaryFile ) {
+    CO2FootprintTextFileObserver(Path co2eFile, Path co2eSummaryFile ) {
         this.co2ePath = co2eFile
         this.co2eSummaryPath = co2eSummaryFile
 
@@ -91,7 +91,7 @@ class CO2FootprintObserver implements TraceObserver {
     }
 
     /** ONLY FOR TESTING PURPOSE */
-    protected CO2FootprintObserver( ) {}
+    protected CO2FootprintTextFileObserver( ) {}
 
     // Load file containing TDP values for different CPU models
     protected void loadCpuTdpData(Map<String,Float> data) {

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintFactoryTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintFactoryTest.groovy
@@ -31,7 +31,7 @@ class CO2FootprintFactoryTest extends Specification {
         def result = new CO2FootprintFactory().create(session)
         then:
         result.size()==1
-        result[0] instanceof CO2FootprintObserver
+        result[0] instanceof CO2FootprintTextFileObserver
     }
 
 }


### PR DESCRIPTION
Renamed `CO2FootprintObserver` to `CO2FootprintTextFileObserver` in accordance with nextflow `TraceFileObserver` class.