### PR TITLE
Fix java dependencies

### DIFF
--- a/buildSrc/src/main/groovy/io.nextflow.groovy-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.nextflow.groovy-common-conventions.gradle
@@ -14,7 +14,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(19)
     }
 }
 

--- a/plugins/nf-co2footprint/build.gradle
+++ b/plugins/nf-co2footprint/build.gradle
@@ -50,7 +50,7 @@ sourceSets {
 }
 
 ext{
-    nextflowVersion = '22.10.0'
+    nextflowVersion = '23.04.0'
 }
 
 dependencies {
@@ -61,10 +61,10 @@ dependencies {
     // add here plugins depepencies
 
     // test configuration
-    testImplementation "org.codehaus.groovy:groovy:3.0.10"
-    testImplementation "org.codehaus.groovy:groovy-nio:3.0.10"
+    testImplementation "org.codehaus.groovy:groovy:3.0.17"
+    testImplementation "org.codehaus.groovy:groovy-nio:3.0.17"
     testImplementation "io.nextflow:nextflow:$nextflowVersion"
-    testImplementation ("org.codehaus.groovy:groovy-test:3.0.10") { exclude group: 'org.codehaus.groovy' }
+    testImplementation ("org.codehaus.groovy:groovy-test:3.0.17") { exclude group: 'org.codehaus.groovy' }
     testImplementation ("cglib:cglib-nodep:3.3.0")
     testImplementation ("org.objenesis:objenesis:3.1")
     testImplementation ("org.spockframework:spock-core:2.2-groovy-3.0") { exclude group: 'org.codehaus.groovy'; exclude group: 'net.bytebuddy' }


### PR DESCRIPTION
The Java dependency problem I observed when using Java 17 and the current nextflow master branch was caused by some issue in the plugin code, which was fixed in the `nf-hello` template (see https://github.com/nextflow-io/nf-hello/commit/6079d28a1faae0b410cbe841bf34083ede326631).

Thus fixing this here as well. 