### PR TITLE
Handle PUE param

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -11,6 +11,7 @@ import groovy.transform.PackageScope
  * co2footprint {
  *     file = "co2footprint.txt"
  *     summaryFile = "co2footprint.summary.txt"
+ *     pue = 1.4
  * }
  *
  *
@@ -25,14 +26,18 @@ class CO2FootprintConfig {
 
     final private String  file
     final private String  summaryFile
+    final private Double  pue // PUE: power usage effectiveness (efficiency coefficient of the data centre)
 
     CO2FootprintConfig(Map map){
         def config = map ?: Collections.emptyMap()
         file = config.file ?: CO2FootprintFactory.CO2FootprintTextFileObserver.DEF_FILE_NAME
         summaryFile = config.summaryFile ?: CO2FootprintFactory.CO2FootprintTextFileObserver.DEF_SUMMARY_FILE_NAME
+        pue = config.pue ?: 1.67
     }
 
     String getFile() { file }
 
     String getSummaryFile() { summaryFile }
+
+    Double getPUE() { pue }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -26,7 +26,7 @@ class CO2FootprintConfig {
 
     final private String  file
     final private String  summaryFile
-    final private Double  pue // PUE: power usage effectiveness (efficiency coefficient of the data centre)
+    final private Double  pue   // PUE: power usage effectiveness efficiency, coefficient of the data centre
 
     CO2FootprintConfig(Map map){
         def config = map ?: Collections.emptyMap()

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -174,7 +174,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
          * Remaining factors
          */
         // PUE: efficiency coefficient of the data centre
-        def pue = 1.67
+        def pue = config.getPUE()
         // CI: carbon intensity [gCO2e kWh−1]
         def ci  = 475
 

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintFactoryTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintFactoryTest.groovy
@@ -49,7 +49,10 @@ class CO2FootprintFactoryTest extends Specification {
         traceRecord.'%cpu' = 100.0
         traceRecord.memory = (7 as Long) * (1000000000 as Long)
 
-        def results = new CO2FootprintFactory().computeTaskCO2footprint(traceRecord)
+        def session = Mock(Session) { getConfig() >> [:] }
+        def factory = new CO2FootprintFactory()
+        factory.create(session)
+        def results = factory.computeTaskCO2footprint(traceRecord)
 
         expect:
         // Energy consumption converted to Wh and compared to result from www.green-algorithms.org

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintFactoryTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintFactoryTest.groovy
@@ -60,4 +60,25 @@ class CO2FootprintFactoryTest extends Specification {
         // CO2 converted to g
         round(results[1]/1000) == 11.59
     }
+
+    def 'test co2e calculation with non-default pue' () {
+        given:
+        def traceRecord = new TraceRecord()
+        traceRecord.realtime = (1 as Long) * (3600000 as Long)
+        traceRecord.cpus = 1
+        traceRecord.cpu_model = "Unknown model"
+        traceRecord.'%cpu' = 100.0
+        traceRecord.memory = (7 as Long) * (1000000000 as Long)
+
+        def session = Mock(Session) { getConfig() >> [co2footprint: [pue: 1.4]] }
+        def factory = new CO2FootprintFactory()
+        factory.create(session)
+        def results = factory.computeTaskCO2footprint(traceRecord)
+
+        expect:
+        // Energy consumption converted to Wh and compared to result from www.green-algorithms.org
+        round(results[0]/1000) == 20.45
+        // CO2 in g
+        round(results[1]/1000) == 9.71
+    }
 }


### PR DESCRIPTION
I added the PUE value to the config and added another test for this.

Defining the default PUE value in the `CO2FootprintConfig` class is inconsistent with the handling of the `file` and `summaryFile` parameters, whose defaults are defined in the `CO2FootprintFactory` class (`CO2FootprintTextFileObserver` subclass). But maybe this can be restructured when we have all parameters handled properly. Or do you have already a suggestion? 