### PR TITLE
Update Nextflow version to 23.07.0-edge

### DIFF
--- a/plugins/nf-co2footprint/build.gradle
+++ b/plugins/nf-co2footprint/build.gradle
@@ -50,7 +50,7 @@ sourceSets {
 }
 
 ext{
-    nextflowVersion = '23.04.0'
+    nextflowVersion = '23.07.0-edge'
 }
 
 dependencies {

--- a/plugins/nf-co2footprint/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-co2footprint/src/resources/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Plugin-Id: nf-co2footprint
 Plugin-Version: 0.4.0
 Plugin-Class: nextflow.co2footprint.CO2FootprintPlugin
 Plugin-Provider: nextflow
-Plugin-Requires: >=22.10.0
+Plugin-Requires: >=23.07.0


### PR DESCRIPTION
Use recent Nextflow edge release with added `cpu_model` trace field.