### PR TITLE
Convert test results units for comparison

### DIFF
--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintFactoryTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintFactoryTest.groovy
@@ -52,9 +52,9 @@ class CO2FootprintFactoryTest extends Specification {
         def results = new CO2FootprintFactory().computeTaskCO2footprint(traceRecord)
 
         expect:
-        // Energy consumption in mWh
-        round(results[0]) == 24394.53
-        // CO2 in mg
-        round(results[1]) == 11587.40
+        // Energy consumption converted to Wh and compared to result from www.green-algorithms.org
+        round(results[0]/1000) == 24.39
+        // CO2 converted to g
+        round(results[1]/1000) == 11.59
     }
 }


### PR DESCRIPTION
Convert units and number of decimal places of the results in tests again for comparison to results from www.green-algorithms.org

I thought we compare the values here to the values from the green algorithm project (for now, as long as we don't change anything in the calculation at least), to avoid that we include errors from our side.