### PR TITLE
Add simple CI handling

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -27,6 +27,7 @@ class CO2FootprintConfig {
 
     final private String  file
     final private String  summaryFile
+    final private Double  ci    // CI: carbon intensity
     final private Double  pue   // PUE: power usage effectiveness efficiency, coefficient of the data centre
     final private Double  powerdrawMem  // Power draw of memory [W per GB]
 
@@ -34,6 +35,7 @@ class CO2FootprintConfig {
         def config = map ?: Collections.emptyMap()
         file = config.file ?: CO2FootprintFactory.CO2FootprintTextFileObserver.DEF_FILE_NAME
         summaryFile = config.summaryFile ?: CO2FootprintFactory.CO2FootprintTextFileObserver.DEF_SUMMARY_FILE_NAME
+        ci = config.ci ?: 475
         pue = config.pue ?: 1.67
         powerdrawMem = config.powerdrawMem ?: 0.3725
     }
@@ -41,6 +43,8 @@ class CO2FootprintConfig {
     String getFile() { file }
 
     String getSummaryFile() { summaryFile }
+
+    Double getCI() { ci }
 
     Double getPUE() { pue }
     Double getPowerdrawMem() { powerdrawMem }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -66,11 +66,8 @@ class CO2FootprintConfig {
     }
 
     String getFile() { file }
-
     String getSummaryFile() { summaryFile }
-
     Double getCI() { ci }
-
     Double getPUE() { pue }
     Double getPowerdrawMem() { powerdrawMem }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -176,7 +176,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
         // PUE: efficiency coefficient of the data centre
         def pue = config.getPUE()
         // CI: carbon intensity [gCO2e kWh−1]
-        def ci  = 475
+        def ci  = config.getCI()
 
         /**
          * Calculate energy consumption [kWh]

--- a/plugins/nf-co2footprint/src/resources/ci_values.csv
+++ b/plugins/nf-co2footprint/src/resources/ci_values.csv
@@ -1,0 +1,2 @@
+country,ci
+Germany,338.66


### PR DESCRIPTION
I added a simple handling of the CI (carbon intensity) parameter.

It can be directly passed over via the config or via a `country` parameter in the config, and then the CI value is retrieved from a CSV file. 
Since I am still not sure how to deal with the licenses best, I just added a simplified version for now to get the plugin running in Germany, and we can see if and how we use the file from the Green Algorithms project later.
