### PR TITLE
Add CFC2 CPU models and corresponding TDP values

### DIFF
--- a/plugins/nf-co2footprint/src/resources/cpu_tdp_values.csv
+++ b/plugins/nf-co2footprint/src/resources/cpu_tdp_values.csv
@@ -1,2 +1,4 @@
 model_name,tdp,cpus,tdp_per_core
 AMD Ryzen Threadripper 2990WX,250,32,7.8
+AMD EPYC 7343,190,16,11.9
+AMD EPYC 7513,200,32,6.3


### PR DESCRIPTION
Add CFC2 CPU models and corresponding TDP values to `cpu_tdp_values.csv`