### PR TITLE
Add further task-specific params to TXT output file

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -42,7 +42,7 @@ class CO2FootprintConfig {
         while ( line = dataReader.readLine() ) {
             def row = line.split(",")
             if (row[0] == country) {
-                localCi = row[1].toFloat()
+                localCi = row[1].toDouble()
                 break
             }
         }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -183,14 +183,12 @@ class CO2FootprintFactory implements TraceObserverFactory {
         /**
          * Calculate energy consumption [kWh]
          */
-        def Double e = (t * (nc * pc * uc + nm * pm) * pue * 0.001) as Double
-        log.info "E: $e"
+        Double e = (t * (nc * pc * uc + nm * pm) * pue * 0.001) as Double
 
         /*
          * Resulting CO2 emission [gCO2e]
          */
-        def Double c = (e * ci) as Double
-        log.info "CO2: $c"
+        Double c = (e * ci)
 
         // Return values in mWh and mg
         e = e * 1000000

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -54,19 +54,19 @@ class CO2FootprintFactory implements TraceObserverFactory {
     final private Map<TaskId,CO2Record> co2eRecords = new ConcurrentHashMap<>()
     // TODO make sure for key value can be set only once?
 
-    private Map<String, Float> cpuData = ['default': (Float) 12.0]
+    private Map<String, Double> cpuData = ['default': (Double) 12.0]
     Double total_energy = 0
     Double total_co2 = 0
 
 
     // Load file containing TDP values for different CPU models
-    protected void loadCpuTdpData(Map<String, Float> data) {
+    protected void loadCpuTdpData(Map<String, Double> data) {
         def dataReader = new InputStreamReader(this.class.getResourceAsStream('/cpu_tdp_values.csv'))
 
         String line
         while ( line = dataReader.readLine() ) {
             def h = line.split(",")
-            if (h[0] != 'model_name') data[h[0]] = h[3].toFloat()
+            if (h[0] != 'model_name') data[h[0]] = h[3].toDouble()
         }
         dataReader.close()
         log.info "$data"
@@ -93,7 +93,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
     }
 
     
-    float getCpuCoreTdp(TraceRecord trace) {
+    Double getCpuCoreTdp(TraceRecord trace) {
         def cpu_model = trace.get('cpu_model').toString()   // TODO toString() in TraceRecord get()?
         log.info "cpu model: $cpu_model"
 

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -155,12 +155,13 @@ class CO2FootprintFactory implements TraceObserverFactory {
          * Factors of memory power usage
          */
         // nm: size of memory available [GB] -> requested memory
-        if ( trace.get('memory') == null ) {
+        Long memory = trace.get('memory') as Long
+        if ( memory == null ) {
             // TODO if 'memory' not set, returns null, hande somehow?
             log.error "TraceRecord field 'memory' is not set!"
             System.exit(1)
         }
-        Double nm = (trace.get('memory') as Long)/1000000000 as Double
+        Double nm = memory/1000000000 as Double
         // TODO handle if more memory/cpus used than requested?
 
         // Pm: power draw of memory [W per GB]
@@ -188,7 +189,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
         e = e * 1000000
         c = c * 1000
 
-        return [e, c, t, nc, pc, uc, nm]
+        return [e, c, t, nc, pc, uc, memory]
     }
 
 
@@ -361,7 +362,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                     cpus,
                     (Double) powerdrawCPU,
                     (Double) cpu_usage,
-                    (Double) memory,
+                    (Long) memory,
                     trace.get('name').toString()
             )
             total_energy += eConsumption
@@ -376,7 +377,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                         + "${cpus}\t"
                         + "${powerdrawCPU}\t"
                         + "${cpu_usage}\t"
-                        + "${memory}GB\t"
+                        + "${HelperFunctions.convertBytesToReadableUnits(memory)}"
                 );
                 it.flush()
             }
@@ -408,7 +409,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                     cpus,
                     (Double) powerdrawCPU,
                     (Double) cpu_usage,
-                    (Double) memory,
+                    (Long) memory,
                     trace.get('name').toString()
             )
             total_energy += eConsumption
@@ -418,12 +419,12 @@ class CO2FootprintFactory implements TraceObserverFactory {
             writer.send {
                 PrintWriter it -> it.println(
                         "${taskId}\t${HelperFunctions.convertToReadableUnits(eConsumption,3)}Wh\t"
-                        + "${HelperFunctions.convertToReadableUnits(co2,3)}g"
+                        + "${HelperFunctions.convertToReadableUnits(co2,3)}g\t"
                         + "${time}h\t"
                         + "${cpus}\t"
                         + "${powerdrawCPU}\t"
                         + "${cpu_usage}\t"
-                        + "${memory}GB\t"
+                        + "${HelperFunctions.convertBytesToReadableUnits(memory)}"
                 );
                 it.flush()
             }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -127,7 +127,8 @@ class CO2FootprintFactory implements TraceObserverFactory {
         // Factor 0.001 needed to convert Pc and Pm from W to kW
 
         // t: runtime in hours
-        Double t = (trace.get('realtime') as Double)/3600000 as Double
+        Double realtime = trace.get('realtime') as Double
+        Double t = realtime/3600000 as Double
 
         /**
          * Factors of core power usage
@@ -189,7 +190,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
         e = e * 1000000
         c = c * 1000
 
-        return [e, c, t, nc, pc, uc, memory]
+        return [e, c, realtime, nc, pc, uc, memory]
     }
 
 
@@ -373,7 +374,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                 PrintWriter it -> it.println(
                         "${taskId}\t${HelperFunctions.convertToReadableUnits(eConsumption,3)}Wh\t"
                         + "${HelperFunctions.convertToReadableUnits(co2,3)}g\t"
-                        + "${time}h\t"
+                        + "${HelperFunctions.convertMillisecondsToReadableUnits(time)}\t"
                         + "${cpus}\t"
                         + "${powerdrawCPU}\t"
                         + "${cpu_usage}\t"
@@ -420,7 +421,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                 PrintWriter it -> it.println(
                         "${taskId}\t${HelperFunctions.convertToReadableUnits(eConsumption,3)}Wh\t"
                         + "${HelperFunctions.convertToReadableUnits(co2,3)}g\t"
-                        + "${time}h\t"
+                        + "${HelperFunctions.convertMillisecondsToReadableUnits(time)}\t"
                         + "${cpus}\t"
                         + "${powerdrawCPU}\t"
                         + "${cpu_usage}\t"

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
@@ -22,11 +22,11 @@ class CO2Record extends TraceRecord {
     private Integer cpus
     private Double powerdrawCPU
     private Double cpuUsage
-    private Double memory
+    private Long memory
     private String name
     // final? or something? to make sure for key value can be set only once?
 
-    CO2Record(Double energy, Double co2e, Double time, Integer cpus, Double powerdrawCPU, Double cpuUsage, Double memory, String name) {
+    CO2Record(Double energy, Double co2e, Double time, Integer cpus, Double powerdrawCPU, Double cpuUsage, Long memory, String name) {
         this.energy = energy
         this.co2e = co2e
         this.time = time

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
@@ -18,20 +18,44 @@ class CO2Record extends TraceRecord {
 
     private Double energy
     private Double co2e
+    private Double time
+    private Integer cpus
+    private Double powerdrawCPU
+    private Double cpuUsage
+    private Double memory
     private String name
     // final? or something? to make sure for key value can be set only once?
 
-    CO2Record(Double energy, Double co2e, String name) {
+    CO2Record(Double energy, Double co2e, Double time, Integer cpus, Double powerdrawCPU, Double cpuUsage, Double memory, String name) {
         this.energy = energy
         this.co2e = co2e
+        this.time = time
+        this.cpus = cpus
+        this.powerdrawCPU = powerdrawCPU
+        this.cpuUsage = cpuUsage
+        this.memory = memory
         this.name = name
-        this.store = new LinkedHashMap<>(['energy': energy, 'co2e': co2e, 'name': name])
+        this.store = new LinkedHashMap<>([
+                'energy':           energy,
+                'co2e':             co2e,
+                'time':             time,
+                'co2e':             co2e,
+                'powerdrawCPU':     powerdrawCPU,
+                'cpuUsage':         cpuUsage,
+                'memory':           memory,
+                'name':             name
+        ])
     }
 
     final public static Map<String,String> FIELDS = [
-        co2e:   'num',
-        energy: 'num',
-        name:   'str'
+        energy:         'num',
+        co2e:           'num',
+        time:           'num',
+        cpus:           'num',
+        powerdrawCPU:   'num',
+        cpuUsage:       'num',
+        memory:         'num',
+        name:           'str'
     ]
 
     // TODO implement accordingly to TraceRecord

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
@@ -13,7 +13,7 @@ public class HelperFunctions {
             value *= 1000
             unitIndex--
         }
-        
+        value = Math.round( value * 100 ) / 100
         return "${value} ${units[unitIndex]}"
     }
 

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
@@ -3,7 +3,7 @@ package nextflow.co2footprint
 public class HelperFunctions {
 
     static public String convertToReadableUnits(double value, int unitIndex=4) {
-        def units = ['p', 'n', 'u', 'm', ' ', 'K', 'M', 'G', 'T', 'P', 'E']  // Units: pico, nano, micro, mili, 0, Kilo, Mega, Giga, Tera, Peta, Exa
+        def units = ['p', 'n', 'u', 'm', ' ', 'K', 'M', 'G', 'T', 'P', 'E']  // Units: pico, nano, micro, milli, 0, Kilo, Mega, Giga, Tera, Peta, Exa
         
         while (value >= 1000 && unitIndex < units.size() - 1) {
             value /= 1000
@@ -17,4 +17,15 @@ public class HelperFunctions {
         return "${value}${units[unitIndex]}"
     }
 
+    static public String convertBytesToReadableUnits(double value) {
+        def units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB']  // Units: pico, nano, micro, milli, 0, Kilo, Mega, Giga, Tera, Peta, Exa
+        int unitIndex=0
+
+        while (value >= 1024 && unitIndex < units.size() - 1) {
+            value /= 1024
+            unitIndex++
+        }
+
+        return "${value} ${units[unitIndex]}"
+    }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
@@ -14,7 +14,7 @@ public class HelperFunctions {
             unitIndex--
         }
         
-        return "${value}${units[unitIndex]}"
+        return "${value} ${units[unitIndex]}"
     }
 
     static public String convertBytesToReadableUnits(double value) {

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
@@ -28,4 +28,22 @@ public class HelperFunctions {
 
         return "${value} ${units[unitIndex]}"
     }
+
+    static public String convertMillisecondsToReadableUnits(double value) {
+        if ( value < 1000 ) {
+            return "${value}ms"
+        } else {
+            int h = Math.floor(value/3600000)
+            int m = Math.floor((value % 3600000)/60000)
+            int s = Math.floor((value % 60000)/1000)
+
+            if ( value < 60000 )
+                return "${s}s"
+            else if ( value < 3600000 )
+                return "${m}m ${s}s"
+            else
+                return "${h}h ${m}m ${s}s"
+        }
+        // TODO also convert to days etc. or could we keep it like this?
+    }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
@@ -18,7 +18,7 @@ public class HelperFunctions {
     }
 
     static public String convertBytesToReadableUnits(double value) {
-        def units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB']  // Units: pico, nano, micro, milli, 0, Kilo, Mega, Giga, Tera, Peta, Exa
+        def units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB']  // Units: Byte, Kilobyte, Megabyte, Gigabyte, Terabyte, Petabyte, Exabyte
         int unitIndex=0
 
         while (value >= 1024 && unitIndex < units.size() - 1) {


### PR DESCRIPTION
- I changed `def Double` to `Double`, because `def` is for variables of unknown type
- added the remaining task-specific params to the `CO2Record` class and added helper function for conversions
- changed some `Float`s to `Double`s to avoid conversion artefacts when converting them to `Double`s (when adding to the list). I would suggest we systematically change the structure afterwards (not assigning those floats to `List<Double>` anymore) and adjust all types to floats where possible. 

I just added the parameters, we should think about restructuring and cleaning up a bit in the near future, when the content is more complete.


