### PR TITLE
Add task params to report

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
@@ -39,7 +39,7 @@ class CO2Record extends TraceRecord {
                 'energy':           energy,
                 'co2e':             co2e,
                 'time':             time,
-                'co2e':             co2e,
+                'cpus':             cpus,
                 'powerdrawCPU':     powerdrawCPU,
                 'cpuUsage':         cpuUsage,
                 'memory':           memory,

--- a/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
+++ b/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
@@ -118,6 +118,7 @@ $(function() {
         unit_index--;
     }
     
+    value = Math.round( value * 100 ) / 100;
     return value + ' ' + units[unit_index];
   }
   

--- a/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
+++ b/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
@@ -140,6 +140,19 @@ $(function() {
     }
   }
 
+  // Convert bytes to readable units
+  function readable_units_memory(bytes){
+    units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB']  // Units: Byte, Kilobyte, Megabyte, Gigabyte, Terabyte, Petabyte, Exabyte
+    unit_index=0
+
+    while (bytes >= 1024 && unit_index < units.length - 1) {
+      bytes /= 1024;
+      unit_index++;
+    }
+    
+    return bytes + ' ' + units[unit_index];
+  }  
+
   // Build the trace table
   function make_co2e(ms, type){
     if (type === 'sort') {
@@ -177,7 +190,7 @@ $(function() {
     }
     return readable_units_time(ms);
   }
-  /*function make_date(ms, type){
+  function make_memory(ms, type){
     if (type === 'sort') {
       return parseInt(ms);
     }
@@ -187,31 +200,8 @@ $(function() {
     if (ms == '-' || ms == 0){
       return ms;
     }
-    return moment( parseInt(ms) ).format();
+    return readable_units_memory(ms);
   }
-  function make_memory(bytes, type){
-    if (type === 'sort') {
-      return parseInt(bytes);
-    }
-    if($('#nf-table-humanreadable').val() == 'false'){
-      return bytes;
-    }
-    if (bytes == '-' || bytes == 0){
-      return bytes;
-    }
-    // https://stackoverflow.com/a/14919494
-    var thresh = 1024;
-    if(Math.abs(bytes) < thresh) {
-      return bytes + ' B';
-    }
-    var units = ['kB','MB','GB','TB','PB','EB','ZB','YB'];
-    var u = -1;
-    do {
-        bytes /= thresh;
-        ++u;
-    } while(Math.abs(bytes) >= thresh && u < units.length - 1);
-    return bytes.toFixed(3)+' '+units[u];
-  }*/
   function make_tasks_table(){
     // reset
       if ( $.fn.dataTable.isDataTable( '#tasks_table' ) ) {

--- a/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
+++ b/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
@@ -259,6 +259,11 @@ $(function() {
           },
           { title: co2EmissionsTitle, data: 'co2e', render: make_co2e },
           { title: energyConsumptionTitle, data: 'energy', render: make_energy },
+          { title: 'Time', data: 'time', render: make_time },
+          { title: 'Number of cores', data: 'cpus' },
+          { title: 'Power draw of a computing core', data: 'powerdrawCPU' },
+          { title: 'Core usage factor', data: 'cpuUsage' },
+          { title: 'Memory', data: 'memory', render: make_memory },
         ],
         "deferRender": true,
         "lengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
@@ -266,7 +271,7 @@ $(function() {
         "colReorder": true,
         "columnDefs": [
           { className: "id", "targets": [ 0,1,2,3 ] },
-          { className: "meta", "targets": [ 4 ] },
+          { className: "meta", "targets": [ 4,7,8,9,10,11 ] },
           { className: "metrics", "targets": [ 5,6 ] }
         ],
         "buttons": [

--- a/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
+++ b/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
@@ -121,19 +121,24 @@ $(function() {
     return value + ' ' + units[unit_index];
   }
   
-  // Humanize duration
-  /*function humanize(duration){
-    if (duration.days() > 0) {
-      return duration.days() + "d " + duration.hours() + "h"
+  // Convert miliseconds to readable units
+  function readable_units_time(duration){
+    if (duration < 1000) {
+      return duration + "ms"
+    } else {
+      hours = Math.floor(duration / 3600000);
+      minutes = Math.floor((duration % 3600000) / 60000);
+      seconds = Math.floor(duration % 60000) / 1000;
+
+      if (duration < 60000) {
+        return seconds + "s";
+      } else if (duration < 3600000) {
+        return minutes + "m " + seconds + "s";
+      } else {
+        return hours + "h " + minutes + "m " + seconds + "s";
+      }
     }
-    if (duration.hours() > 0) {
-      return duration.hours() + "h " + duration.minutes() + "m"
-    }
-    if (duration.minutes() > 0) {
-      return duration.minutes() + "m " + duration.seconds() + "s"
-    }
-    return duration.asSeconds().toFixed(1) + "s"
-  }*/
+  }
 
   // Build the trace table
   function make_co2e(ms, type){
@@ -160,7 +165,7 @@ $(function() {
     }
     return readable_units(ms, 3) + 'Wh';
   }
-  /*function make_duration(ms, type){
+  function make_time(ms, type){
     if (type === 'sort') {
       return parseInt(ms);
     }
@@ -170,9 +175,9 @@ $(function() {
     if (ms == '-' || ms == 0){
       return ms;
     }
-    return humanize(moment.duration( parseInt(ms) ));
+    return readable_units_time(ms);
   }
-  function make_date(ms, type){
+  /*function make_date(ms, type){
     if (type === 'sort') {
       return parseInt(ms);
     }


### PR DESCRIPTION
Add task specific params to the report table.
- Added time, cpus, powerdrawCPU, cpuUsage and memory
- Modify JS unit conversion functions to work as the groovy helper functions

Example (raw values)
![image](https://github.com/qbic-pipelines/nf-co2footprint/assets/8224255/d68945a0-a075-4ed5-b969-cba89ed17637)
Example (human readable)
![image](https://github.com/qbic-pipelines/nf-co2footprint/assets/8224255/0c376e5c-68fe-4e0c-a135-a8906ecb7b83)
- I classified them as metadata, as metrics I left CO2 emissions and energy consumption which are the final metrics